### PR TITLE
[MCC-198993][NRTM] Add Local Tracing

### DIFF
--- a/lib/zipkin-tracer.rb
+++ b/lib/zipkin-tracer.rb
@@ -1,6 +1,7 @@
 require 'base64' #Bug in finagle. They should be requiring this: finagle-thrift-1.4.1/lib/finagle-thrift/tracer.rb:115
 require 'zipkin-tracer/trace'
 require 'zipkin-tracer/rack/zipkin-tracer'
+require 'zipkin-tracer/trace_client'
 
 begin
   require 'faraday'

--- a/lib/zipkin-tracer/rack/zipkin-tracer.rb
+++ b/lib/zipkin-tracer/rack/zipkin-tracer.rb
@@ -80,6 +80,7 @@ module ZipkinTracer
     ensure
       synchronize do
         annotate_plugin(zipkin_env.env, status, headers, body)
+        TraceClientCollection.record_and_clear(headers) { |annotation| @tracer.record(trace_id, annotation) }
         @tracer.record(trace_id, Trace::Annotation.new(Trace::Annotation::SERVER_SEND, Trace.default_endpoint))
       end
     end

--- a/lib/zipkin-tracer/trace_client.rb
+++ b/lib/zipkin-tracer/trace_client.rb
@@ -1,0 +1,63 @@
+module ZipkinTracer
+  class TraceClient
+    ENV_REQUEST_ID = 'action_dispatch.request_id'.freeze
+    LOCAL_COMPONENT = 'lc'.freeze
+    STRING_TYPE = 'STRING'.freeze
+
+    def initialize(env)
+      @request_id = env && env[ENV_REQUEST_ID]
+    end
+
+    def trace(key = caller_locations(1).first.label)  # set caller method name if "key" is missing
+      if block_given?
+        record "Start: #{key}"
+        yield self
+        record "End: #{key}"
+      end
+    end
+
+    def record(key)
+      TraceClientCollection.add_annotation(@request_id, Trace::Annotation.new(key, Trace.default_endpoint)) if @request_id
+    end
+
+    def record_binary(key, value)
+      TraceClientCollection.add_annotation(@request_id, Trace::BinaryAnnotation.new(key, value, STRING_TYPE, Trace.default_endpoint)) if @request_id
+    end
+
+    def record_local_component(value)
+      record_binary(LOCAL_COMPONENT, value)
+    end
+  end
+
+
+  class TraceClientCollection
+    HEADER_REQUEST_ID = 'X-Request-Id'.freeze
+    LIFE_SPAN = 10
+
+    @annotations = {}
+
+    def self.add_annotation(request_id, annotaion)
+      @annotations[request_id] ||= {}
+      @annotations[request_id][:updated_at] = DateTime.now
+      @annotations[request_id][:items] ||= []
+      @annotations[request_id][:items] << annotaion
+    end
+
+    def self.record_and_clear(headers)
+      request_id = headers[HEADER_REQUEST_ID]
+      annotations(request_id).each do |annotation|
+        yield(annotation)
+      end
+      clear(request_id)
+    end
+
+    def self.annotations(request_id)
+      (@annotations[request_id] && @annotations[request_id][:items]) || []
+    end
+
+    def self.clear(request_id)
+      @annotations.delete(request_id)
+      @annotations.delete_if {|key, value| value[:updated_at] < LIFE_SPAN.minute.ago }  # trush garbage
+    end
+  end
+end


### PR DESCRIPTION
Implement local trace for Zipkin.  
I'm working on specs right now.

Please have a look my code.

@jfeltesse-mdsol @jcarres-mdsol @cabbott @ssteeg-mdsol

Special thanks to @lschreck-mdsol @bvillanueva-mdsol !! :bow:

Annotations are stored in a class instance variable of TraceClientCollection class,
and they will record to Zipkin tracer in RackHandler after receiving response. 

Here is sample code to record local traces.( in Rails controller )

```Ruby
    ztc = ZipkinTracer::TraceClient.new(request.env)
    ztc.trace do
      ztc.record_local_component "Local Trace Sample"
      ztc.record_binary "key", "testtesttest"
      sleep 10
    end
```


On Zipkin server, it shows like this.
<img width="718" alt="screen shot 2016-01-20 at 5 28 39 pm" src="https://cloud.githubusercontent.com/assets/16286071/12443455/45f3a778-bf9b-11e5-92c8-b13908e9f379.png">


I have one concern about this implementation.
HTTP Request ID is used to trace a request.
Is there any possibility that Request ID is missing in HTTP Response Header?
